### PR TITLE
add functions to encode / decode values between Go and JS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+SHELL=/bin/bash
+
+.PHONY: test
+test:
+	@PATH=$$(go env GOROOT)/misc/wasm:$$PATH GOOS=js GOARCH=wasm go test -v ./...

--- a/encoding/json.go
+++ b/encoding/json.go
@@ -1,0 +1,27 @@
+package encoding
+
+import (
+	"encoding/json"
+	"syscall/js"
+)
+
+var jsjson = js.Global().Get("JSON")
+
+// MarshalJSONValue encodes a Go value into a JavaScript value.
+// The encoding is done via Go's encoding/json.Marshal and JavaScript's JSON.parse.
+func MarshalJSONValue(v any) (js.Value, error) {
+	value, err := json.Marshal(v)
+	if err != nil {
+		return js.Value{}, err
+	}
+	parsed := jsjson.Call("parse", string(value))
+	return parsed, nil
+}
+
+// UnmarshalJSONValue decodes a JavaScript value into a Go value.
+// The decoding is done via JavaScript's JSON.stringify and Go's encoding/json.Unmarshal.
+func UnmarshalJSONValue(src js.Value, v any) error {
+	stringified := jsjson.Call("stringify", src)
+	str := stringified.String()
+	return json.Unmarshal([]byte(str), v)
+}

--- a/encoding/json_test.go
+++ b/encoding/json_test.go
@@ -1,0 +1,127 @@
+package encoding
+
+import (
+	"reflect"
+	"syscall/js"
+	"testing"
+)
+
+type Example struct {
+	Field1 string `json:"field1"`
+	Field2 string `json:"field2"`
+}
+
+func TestMarshalJSONValue(t *testing.T) {
+	tests := map[string]struct {
+		v           any
+		wantJSValue js.Value
+		isPrimitive bool
+	}{
+		"string": {
+			v:           "hello",
+			wantJSValue: js.ValueOf("hello"),
+			isPrimitive: true,
+		},
+		"number": {
+			v:           42,
+			wantJSValue: js.ValueOf(42),
+			isPrimitive: true,
+		},
+		"bool": {
+			v:           true,
+			wantJSValue: js.ValueOf(true),
+			isPrimitive: true,
+		},
+		"slice": {
+			v:           []any{"a", "b", "c"},
+			wantJSValue: js.ValueOf([]any{"a", "b", "c"}),
+			isPrimitive: false,
+		},
+		"map": {
+			// map keys can't be sorted, so we use single key Object.
+			v:           map[string]any{"a": "b"},
+			wantJSValue: js.ValueOf(map[string]any{"a": "b"}),
+			isPrimitive: false,
+		},
+		"struct": {
+			v:           Example{Field1: "f1", Field2: "f2"},
+			wantJSValue: js.ValueOf(map[string]any{"field1": "f1", "field2": "f2"}),
+			isPrimitive: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotJSValue, err := MarshalJSONValue(tc.v)
+			if err != nil {
+				t.Fatalf("want err: nil, got: %v", err)
+			}
+			if tc.isPrimitive {
+				if !tc.wantJSValue.Equal(gotJSValue) {
+					t.Fatalf("want equal: true, got: false")
+				}
+				return
+			}
+			// We can't compare the two js.Value directly, so we compare their string representation.
+			wantJSStr := jsjson.Call("stringify", tc.wantJSValue).String()
+			gotJSStr := jsjson.Call("stringify", gotJSValue).String()
+			if wantJSStr != gotJSStr {
+				t.Fatalf("want: %s, got: %s", wantJSStr, gotJSStr)
+			}
+		})
+	}
+}
+
+func TestUnmarshalJSONValue(t *testing.T) {
+	tests := map[string]struct {
+		src  js.Value
+		want any
+	}{
+		"string": {
+			src:  js.ValueOf("hello"),
+			want: "hello",
+		},
+		"number": {
+			src: js.ValueOf(42),
+			// JavaScript's number is converted into float64 implicitly.
+			want: float64(42),
+		},
+		"bool": {
+			src:  js.ValueOf(true),
+			want: true,
+		},
+		"slice": {
+			src:  js.ValueOf([]any{"a", "b", "c"}),
+			want: []any{"a", "b", "c"},
+		},
+		"map": {
+			// map keys can't be sorted, so we use single key Object.
+			src:  js.ValueOf(map[string]any{"a": "b"}),
+			want: map[string]any{"a": "b"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var got any
+			if err := UnmarshalJSONValue(tc.src, &got); err != nil {
+				t.Fatalf("want err: nil, got: %v", err)
+			}
+			if !reflect.DeepEqual(tc.want, got) {
+				t.Fatalf("want: %v, got: %v", tc.want, got)
+			}
+		})
+	}
+
+	t.Run("struct", func(t *testing.T) {
+		src := js.ValueOf(map[string]any{"field1": "f1", "field2": "f2"})
+		var got Example
+		if err := UnmarshalJSONValue(src, &got); err != nil {
+			t.Fatalf("want err: nil, got: %v", err)
+		}
+		want := Example{Field1: "f1", Field2: "f2"}
+		if want != got {
+			t.Fatalf("want: %v, got: %v", want, got)
+		}
+	})
+}


### PR DESCRIPTION
I added these functions because I thought they might be useful for encoding/decoding Cloudflare's queue consumer handler message body.